### PR TITLE
Fixed template M size function and formatting.

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,67 @@
+# Format Style Options - Created with Clang Power Tools
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+ColumnLimit: 120
+CommentPragmas: ''
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros: 
+  []
+IncludeBlocks: Preserve
+IncludeCategories: 
+  []
+IncludeIsMainRegex: $
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments: true
+SortIncludes: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++11
+TabWidth: 8
+UseTab: Never
+...

--- a/src/array.h
+++ b/src/array.h
@@ -20,84 +20,86 @@
 
 #include "shareddata.h"
 #include "tinyvector.h"
+#include <array>
 
-template< typename T, int N >
+template <typename T, int N>
 class Array
 {
 public:
     Array();
-    Array( const TinyVector<int,N>& sizes );
+    Array(const TinyVector<int, N> &sizes);
 
-    const TinyVector<int,N>& sizes() const;
+    const TinyVector<int, N> &sizes() const;
 
-    const T& at( const TinyVector<int,N>& indices ) const;
-    const T& operator() ( const TinyVector<int,N>& indices ) const;
-    T& operator() ( const TinyVector<int,N>& indices );
+    const T &at(const TinyVector<int, N> &indices) const;
+    const T &operator()(const TinyVector<int, N> &indices) const;
+    T &operator()(const TinyVector<int, N> &indices);
 
-    Array<T,N> subarray( const TinyVector<int,N>& begin,
-                         const TinyVector<int,N>& end );
+    Array<T, N> subarray(const TinyVector<int, N> &begin,
+                         const TinyVector<int, N> &end);
 
 private:
-    int dataIndex( const TinyVector<int,N>& indices ) const;
+    int dataIndex(const TinyVector<int, N> &indices) const;
 
 private:
     SharedData<T> data_;
     int offset_;
-    TinyVector<int,N> strides_;
-    TinyVector<int,N> sizes_;
+    TinyVector<int, N> strides_;
+    TinyVector<int, N> sizes_;
 };
 
-template< typename T, int N >
-Array<T,N>::Array()
-    : data_(0)
-    , sizes_(0)
+template <typename T, int N>
+Array<T, N>::Array()
+    : data_(0), sizes_(0)
 {
 }
 
-template< typename T, int N >
-Array<T,N>::Array( const TinyVector<int,N>& sizes )
-    : data_( new T[prod(sizes)] )
-    , offset_(0)
-    , strides_( cumprod(sizes)/sizes(0) )
-    , sizes_(sizes)
+template <typename T, int N>
+Array<T, N>::Array(const TinyVector<int, N> &sizes)
+    : data_(new T[prod(sizes)]), offset_(0), strides_(cumprod(sizes) / sizes(0)), sizes_(sizes)
 {
 }
 
-//template< typename T, int N >
-
-template< typename T, int N >
-const T& Array<T,N>::at( const TinyVector<int,N>& indices ) const
+template <typename T, int N>
+const TinyVector<int, N> &Array<T, N>::sizes() const
 {
-    return data_[ dataIndex(indices) ];
+    return sizes_;
 }
 
-template< typename T, int N >
-const T& Array<T,N>::operator() ( const TinyVector<int,N>& indices ) const
+template <typename T, int N>
+const T &Array<T, N>::at(const TinyVector<int, N> &indices) const
+{
+    return data_[dataIndex(indices)];
+}
+
+template <typename T, int N>
+const T &Array<T, N>::operator()(const TinyVector<int, N> &indices) const
 {
     return at(indices);
 }
 
-template< typename T, int N >
-T& Array<T,N>::operator() ( const TinyVector<int,N>& indices )
+template <typename T, int N>
+T &Array<T, N>::operator()(const TinyVector<int, N> &indices)
 {
-    return data_[ dataIndex(indices) ];
+    return data_[dataIndex(indices)];
 }
 
-template< typename T, int N >
-int Array<T,N>::dataIndex( const TinyVector<int,N>& indices ) const
+template <typename T, int N>
+int Array<T, N>::dataIndex(const TinyVector<int, N> &indices) const
 {
-    for ( int i = 0; i < N; ++i ) {
-        assert( indices(i) >= 0 && indices(i) < sizes_(i) );
+    for (int i = 0; i < N; ++i)
+    {
+        assert(indices(i) >= 0 && indices(i) < sizes_(i));
     }
 
-    return offset_ + sum( indices * strides_ );
+    return offset_ + sum(indices * strides_);
 }
 
-template< typename T, int N >
-Array<T,N> Array<T,N>::subarray( const TinyVector<int,N>& begin,
-                                 const TinyVector<int,N>& end )
+template <typename T, int N>
+Array<T, N> Array<T, N>::subarray(const TinyVector<int, N> &begin,
+                                  const TinyVector<int, N> &end)
 {
-    Array<T,N> sub;
+    Array<T, N> sub;
     sub.data_ = data_;
     sub.offset_ = dataIndex(begin);
     sub.strides_ = strides_;


### PR DESCRIPTION
Fixed the following function `template <typename T, int N>
const TinyVector<int, N> &Array<T, N>::sizes() const
{
    return sizes_;
}`
and formatting.